### PR TITLE
Secure version loading with validation and sanitization

### DIFF
--- a/pkg/api/version.go
+++ b/pkg/api/version.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"regexp"
+	"strings"
 )
 
 type VersionResponse struct {
@@ -12,6 +14,10 @@ type VersionResponse struct {
 }
 
 var version string = ""
+
+// versionRegex validates that the version string follows a safe format.
+// It allows an optional 'v' prefix, followed by digits and dots (e.g., v1.2.3, 0.1).
+var versionRegex = regexp.MustCompile(`^v?\d+(\.\d+)*(-[\w\.-]+)?$`)
 
 func VersionHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
@@ -41,7 +47,13 @@ func loadVersion() string {
 		slog.Error("Error: not able to read version file", "error", err)
 		version = "Unknown"
 	} else {
-		version = string(versionValue)
+		v := strings.TrimSpace(string(versionValue))
+		if versionRegex.MatchString(v) {
+			version = v
+		} else {
+			slog.Warn("Warning: version file contains invalid or unsafe characters", "value", v)
+			version = "Unknown"
+		}
 	}
 	return version
 }

--- a/pkg/api/version_test.go
+++ b/pkg/api/version_test.go
@@ -58,6 +58,51 @@ func TestVersionHandler(t *testing.T) {
 	deleteTempVersionFile(versionFilePath)
 }
 
+func TestLoadVersionInvalid(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "XSS script tag",
+			content:  "<script>alert(1)</script>",
+			expected: "Unknown",
+		},
+		{
+			name:     "Invalid characters",
+			content:  "1.2.3; drop table users",
+			expected: "Unknown",
+		},
+		{
+			name:     "Valid version with spaces",
+			content:  "  v1.2.3  \n",
+			expected: "v1.2.3",
+		},
+		{
+			name:     "Valid semantic version with hyphen",
+			content:  "1.0.0-beta.1",
+			expected: "1.0.0-beta.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version = ""
+			versionFilePath := createTempVersionFile(tt.content)
+			t.Setenv("UC_VERSION_PATH", versionFilePath)
+
+			result := loadVersion()
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+
+			deleteTempVersionFile(versionFilePath)
+		})
+	}
+}
+
 func TestLoadVersionNotFound(t *testing.T) {
 	version = ""
 	t.Setenv("UC_VERSION_PATH", "does_not_exist_version_file")


### PR DESCRIPTION
This PR addresses a potential security vulnerability where a compromised version file could inject malicious scripts or characters into the API response. I've implemented a regex-based validation check and input sanitization (trimming whitespace) in `pkg/api/version.go`. Additionally, I've added unit tests in `pkg/api/version_test.go` to cover various scenarios, including XSS attempts and invalid characters, ensuring they are correctly handled and defaulted to "Unknown".

---
*PR created automatically by Jules for task [16385731093658883556](https://jules.google.com/task/16385731093658883556) started by @nikfarjam*