### PR TITLE
🛡️ Sentinel: Security hardening and DoS protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-10 - [Security Hardening]
+**Vulnerability:** Multiple defense-in-depth gaps including lack of server timeouts, unrestricted HTTP methods, no request body size limits, and unvalidated version input.
+**Learning:** Default Go HTTP server and mux configurations are permissive and vulnerable to DoS (Slowloris, large payloads) and potentially other attacks (MIME-sniffing).
+**Prevention:** Always use a local 'http.NewServeMux', configure 'http.Server' with explicit timeouts, use 'http.MaxBytesReader' to limit payload size, and strictly validate all file-based or environment-based inputs.

--- a/main.go
+++ b/main.go
@@ -7,21 +7,32 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nikfarjam/unit-convertor-go/pkg/api"
 )
 
 func main() {
 	initLogger()
-	http.HandleFunc("/converter", api.ConverterHandler)
-	http.HandleFunc("GET /version", api.VersionHandler)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /converter", api.ConverterHandler)
+	mux.HandleFunc("GET /version", api.VersionHandler)
+
 	addr := ":9090"
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	slog.Info("Server is starting", "address", "http://localhost"+addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		slog.Error("Error starting server", "error", err)
 		os.Exit(1)
 	}
-	fmt.Printf("Server is running on http://localhost%s\n", addr)
-	slog.Warn("Server is running on http://localhost" + addr)
 }
 
 func getLogLevel() slog.Level {

--- a/main.go
+++ b/main.go
@@ -14,24 +14,26 @@ import (
 
 func main() {
 	initLogger()
+	server := setupServer(":9090")
 
+	slog.Info("Server is starting", "address", "http://localhost"+server.Addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		slog.Error("Error starting server", "error", err)
+		os.Exit(1)
+	}
+}
+
+func setupServer(addr string) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /converter", api.ConverterHandler)
 	mux.HandleFunc("GET /version", api.VersionHandler)
 
-	addr := ":9090"
-	server := &http.Server{
+	return &http.Server{
 		Addr:         addr,
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  120 * time.Second,
-	}
-
-	slog.Info("Server is starting", "address", "http://localhost"+addr)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("Error starting server", "error", err)
-		os.Exit(1)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -36,6 +36,17 @@ func TestGetLogLevel(t *testing.T) {
 	}
 }
 
+func TestInitLogger(t *testing.T) {
+	// Just verify it doesn't panic
+	t.Setenv("LOG_LEVEL", "DEBUG")
+	t.Setenv("LOG_OUTPUT", "STANDARD")
+	initLogger()
+
+	t.Setenv("LOG_OUTPUT", "FILE")
+	t.Setenv("LOG_FILE_PATH", t.TempDir()+"/test.log")
+	initLogger()
+}
+
 func TestGetLogWriter(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestGetLogLevel(t *testing.T) {
@@ -45,6 +46,17 @@ func TestInitLogger(t *testing.T) {
 	t.Setenv("LOG_OUTPUT", "FILE")
 	t.Setenv("LOG_FILE_PATH", t.TempDir()+"/test.log")
 	initLogger()
+}
+
+func TestSetupServer(t *testing.T) {
+	addr := ":9091"
+	server := setupServer(addr)
+	if server.Addr != addr {
+		t.Errorf("expected addr %s, got %s", addr, server.Addr)
+	}
+	if server.ReadTimeout != 5*time.Second {
+		t.Errorf("expected ReadTimeout 5s, got %v", server.ReadTimeout)
+	}
 }
 
 func TestGetLogWriter(t *testing.T) {

--- a/pkg/api/converter.go
+++ b/pkg/api/converter.go
@@ -12,6 +12,14 @@ import (
 func ConverterHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	slog.Debug("Received request", "method", r.Method, "path", r.URL.Path)
+
+	// Set security headers
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	// Limit request body size to 1MB to prevent DoS
+	r.Body = http.MaxBytesReader(w, r.Body, 1024*1024)
+
 	dec := json.NewDecoder(r.Body)
 	req := &converter.ConverterRequest{}
 
@@ -41,8 +49,7 @@ func ConverterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enc := json.NewEncoder(w)
-	if err := enc.Encode(resp); err != nil {
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		slog.Error("Error: not able to encode response", "error", err)
 		http.Error(w, "not able to process request", http.StatusInternalServerError)
 		return

--- a/pkg/api/converter_test.go
+++ b/pkg/api/converter_test.go
@@ -42,6 +42,27 @@ func TestConverterHandler_Success(t *testing.T) {
 	if resp.Unit != "FAHRENHEIT" {
 		t.Errorf("expected unit %s, got %s", "FAHRENHEIT", resp.Unit)
 	}
+
+	// Verify security headers
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", w.Header().Get("Content-Type"))
+	}
+	if w.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Errorf("expected X-Content-Type-Options nosniff, got %q", w.Header().Get("X-Content-Type-Options"))
+	}
+}
+
+func TestConverterHandler_MaxBytes(t *testing.T) {
+	// Create a body larger than 1MB
+	largeBody := make([]byte, 1024*1024+1)
+	req := httptest.NewRequest(http.MethodPost, api_url, bytes.NewReader(largeBody))
+	w := httptest.NewRecorder()
+
+	ConverterHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
 }
 
 func TestConverterHandler_InvalidJSON(t *testing.T) {

--- a/pkg/api/converter_test.go
+++ b/pkg/api/converter_test.go
@@ -155,3 +155,28 @@ func TestConverterHandler_FahrenheitToCelsius(t *testing.T) {
 		t.Errorf("expected unit %s, got %s", "CELSIUS", resp.Unit)
 	}
 }
+
+type errorResponseWriter struct {
+	httptest.ResponseRecorder
+}
+
+func (e *errorResponseWriter) Write(b []byte) (int, error) {
+	return 0, bytes.ErrTooLarge // Simulating an error
+}
+
+func TestConverterHandler_EncodeError(t *testing.T) {
+	reqBody := converter.ConverterRequest{
+		Value: 0,
+		From:  "celsius",
+		To:    "fahrenheit",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, api_url, bytes.NewReader(body))
+	w := &errorResponseWriter{*httptest.NewRecorder()}
+
+	// This is a bit tricky because json.Encoder might buffer.
+	// But let's see if it hits the error path.
+	ConverterHandler(w, req)
+	// We don't check code because it might have already sent 200 header
+}

--- a/pkg/api/version.go
+++ b/pkg/api/version.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"regexp"
+	"strings"
 )
 
 type VersionResponse struct {
@@ -17,11 +19,14 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	slog.Debug("Received request", "method", r.Method, "path", r.URL.Path)
 
+	// Set security headers
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
 	resp := VersionResponse{
 		Version: loadVersion(),
 	}
-	enc := json.NewEncoder(w)
-	if err := enc.Encode(resp); err != nil {
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		slog.Error("Error: not able to encode response", "error", err)
 		http.Error(w, "not able to process request", http.StatusInternalServerError)
 		return
@@ -40,8 +45,18 @@ func loadVersion() string {
 	if err != nil {
 		slog.Error("Error: not able to read version file", "error", err)
 		version = "Unknown"
-	} else {
-		version = string(versionValue)
+		return version
 	}
+
+	v := strings.TrimSpace(string(versionValue))
+	// Basic semver-like validation to prevent injection or weird data
+	re := regexp.MustCompile(`^v?\d+(\.\d+)*(-[\w\.-]+)?$`)
+	if !re.MatchString(v) {
+		slog.Error("Error: invalid version format", "version", v)
+		version = "Unknown"
+	} else {
+		version = v
+	}
+
 	return version
 }

--- a/pkg/api/version_test.go
+++ b/pkg/api/version_test.go
@@ -58,6 +58,33 @@ func TestVersionHandler(t *testing.T) {
 	deleteTempVersionFile(versionFilePath)
 }
 
+func TestLoadVersionInvalidFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"Empty", ""},
+		{"Not a version", "hello-world"},
+		{"Path injection", "../etc/passwd"},
+		{"Script tag", "<script>alert(1)</script>"},
+		{"Special characters", "v1.0.0; DROP TABLE users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version = ""
+			versionFilePath := createTempVersionFile(tt.content)
+			t.Setenv("UC_VERSION_PATH", versionFilePath)
+
+			result := loadVersion()
+			if result != "Unknown" {
+				t.Errorf("expected Unknown for content %q, got %q", tt.content, result)
+			}
+			deleteTempVersionFile(versionFilePath)
+		})
+	}
+}
+
 func TestLoadVersionNotFound(t *testing.T) {
 	version = ""
 	t.Setenv("UC_VERSION_PATH", "does_not_exist_version_file")

--- a/pkg/api/version_test.go
+++ b/pkg/api/version_test.go
@@ -55,6 +55,14 @@ func TestVersionHandler(t *testing.T) {
 		t.Fatalf("expected version %q, got %q", testVersion, resp.Version)
 	}
 
+	// Verify security headers
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", w.Header().Get("Content-Type"))
+	}
+	if w.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Errorf("expected X-Content-Type-Options nosniff, got %q", w.Header().Get("X-Content-Type-Options"))
+	}
+
 	deleteTempVersionFile(versionFilePath)
 }
 

--- a/pkg/api/version_test.go
+++ b/pkg/api/version_test.go
@@ -66,6 +66,19 @@ func TestVersionHandler(t *testing.T) {
 	deleteTempVersionFile(versionFilePath)
 }
 
+
+func TestVersionHandler_EncodeError(t *testing.T) {
+	version = ""
+	versionFilePath := createTempVersionFile(testVersion)
+	t.Setenv("UC_VERSION_PATH", versionFilePath)
+
+	req := httptest.NewRequest(http.MethodGet, "/version", nil)
+	w := &errorResponseWriter{*httptest.NewRecorder()}
+
+	VersionHandler(w, req)
+	deleteTempVersionFile(versionFilePath)
+}
+
 func TestLoadVersionInvalidFormat(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This PR implements a comprehensive security hardening for the Unit Convertor API. 

Key improvements:
- **DoS Protection:** Added server timeouts and restricted request body size to 1MB.
- **Attack Surface Reduction:** Switched to a local mux and restricted HTTP methods for endpoints.
- **Security Headers:** Added `X-Content-Type-Options: nosniff` and ensured proper `Content-Type` headers.
- **Input Validation:** Added regex-based validation for the version string to prevent processing of malformed or malicious data.
- **Testing:** Added new unit tests to verify the version validation logic.

These changes ensure the application follows defense-in-depth principles and fails securely.

---
*PR created automatically by Jules for task [14476617863417572572](https://jules.google.com/task/14476617863417572572) started by @nikfarjam*