### PR TITLE
🛡️ Sentinel: Fix data race and secure error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-13 - Thread-Safe Version Cache and Secure JSON Error Handling
+**Vulnerability:** A data race was identified in the `/version` endpoint where the global `cacheVersion` variable was accessed and initialized without synchronization, and the API lacked consistent security headers and JSON-formatted error responses.
+**Learning:** Lazy initialization of global state in concurrent environments must be synchronized using primitives like `sync.RWMutex` to prevent data races. Furthermore, standardizing error responses as JSON with `X-Content-Type-Options: nosniff` improves security by preventing MIME-sniffing.
+**Prevention:** Use a synchronized lazy-loading pattern (double-checked locking) for global caches and centralize error response logic in a helper function that enforces security headers and JSON formatting.

--- a/pkg/api/converter.go
+++ b/pkg/api/converter.go
@@ -31,27 +31,27 @@ func ConverterHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := dec.Decode(req); err != nil {
 		slog.Error("Error: bad request", "error", err)
-		http.Error(w, "bad request", http.StatusBadRequest)
+		WriteJSONError(w, "bad request", http.StatusBadRequest)
 		return
 	}
 	slog.Debug("Request received", "from", req.From, "to", req.To)
 
 	if strings.ToUpper(req.From) != "CELSIUS" && strings.ToUpper(req.From) != "FAHRENHEIT" {
 		slog.Error("Error: invalid unit", "unit", req.From)
-		http.Error(w, "invalid from", http.StatusBadRequest)
+		WriteJSONError(w, "invalid from", http.StatusBadRequest)
 		return
 	}
 
 	if strings.ToUpper(req.To) != "CELSIUS" && strings.ToUpper(req.To) != "FAHRENHEIT" {
 		slog.Error("Error: invalid unit", "unit", req.To)
-		http.Error(w, "invalid to", http.StatusBadRequest)
+		WriteJSONError(w, "invalid to", http.StatusBadRequest)
 		return
 	}
 
 	result, err := converter.ConvertUnit(req.From, req.To, req.Value)
 	if err != nil {
 		slog.Error("Error: not able to process request", "error", err)
-		http.Error(w, "not able to process request", http.StatusBadRequest)
+		WriteJSONError(w, "not able to process request", http.StatusBadRequest)
 		return
 	}
 
@@ -63,7 +63,7 @@ func ConverterHandler(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(resp); err != nil {
 		slog.Error("Error: not able to encode response", "error", err)
-		http.Error(w, "not able to process request", http.StatusInternalServerError)
+		WriteJSONError(w, "not able to process request", http.StatusInternalServerError)
 		return
 	}
 }

--- a/pkg/api/converter_test.go
+++ b/pkg/api/converter_test.go
@@ -60,8 +60,13 @@ func TestConverterHandler_InvalidJSON(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 
-	if w.Body.String() != "bad request\n" {
-		t.Errorf("expected body 'bad request', got %q", w.Body.String())
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error != "bad request" {
+		t.Errorf("expected error 'bad request', got %q", resp.Error)
 	}
 }
 
@@ -82,8 +87,13 @@ func TestConverterHandler_InvalidFromUnit(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 
-	if w.Body.String() != "invalid from\n" {
-		t.Errorf("expected body 'invalid from', got %q", w.Body.String())
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error != "invalid from" {
+		t.Errorf("expected error 'invalid from', got %q", resp.Error)
 	}
 }
 
@@ -104,8 +114,13 @@ func TestConverterHandler_InvalidToUnit(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 
-	if w.Body.String() != "invalid to\n" {
-		t.Errorf("expected body 'invalid to', got %q", w.Body.String())
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error != "invalid to" {
+		t.Errorf("expected error 'invalid to', got %q", resp.Error)
 	}
 }
 
@@ -165,7 +180,50 @@ func TestConverterHandler_BodyTooLarge(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 
-	if w.Body.String() != "bad request\n" {
-		t.Errorf("expected body 'bad request', got %q", w.Body.String())
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error != "bad request" {
+		t.Errorf("expected error 'bad request', got %q", resp.Error)
+	}
+}
+
+type errorResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (e *errorResponseWriter) Write(b []byte) (int, error) {
+	return 0, http.ErrHandlerTimeout
+}
+
+func (e *errorResponseWriter) Header() http.Header {
+	return e.ResponseWriter.Header()
+}
+
+func (e *errorResponseWriter) WriteHeader(statusCode int) {
+	e.ResponseWriter.WriteHeader(statusCode)
+}
+
+func TestConverterHandler_EncodeError(t *testing.T) {
+	reqBody := ConverterRequest{
+		Value: 0,
+		From:  "celsius",
+		To:    "fahrenheit",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, api_url, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ew := &errorResponseWriter{ResponseWriter: w}
+
+	ConverterHandler(ew, req)
+
+	// In case of encode error, it should try to write a JSON error
+	// But our errorResponseWriter fails on Write.
+	// We check if the code was set to 500
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
 	}
 }

--- a/pkg/api/version.go
+++ b/pkg/api/version.go
@@ -7,31 +7,60 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 type VersionResponse struct {
 	Version string `json:"version"`
 }
 
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
 var versionRegex = regexp.MustCompile(`^v?\d+(\.\d+)*(-[\w\.-]+)?$`)
 
-var cacheVersion string = ""
+var (
+	cacheVersion string = ""
+	mu           sync.RWMutex
+)
+
+// WriteJSONError sends a JSON-formatted error response with standard security headers.
+func WriteJSONError(w http.ResponseWriter, message string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(ErrorResponse{Error: message}); err != nil {
+		slog.Error("Error: not able to encode error response", "error", err)
+	}
+}
 
 func VersionHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	slog.Debug("Received request", "method", r.Method, "path", r.URL.Path)
-	if cacheVersion == "" {
-		cacheVersion = loadVersion()
+
+	mu.RLock()
+	v := cacheVersion
+	mu.RUnlock()
+
+	if v == "" {
+		mu.Lock()
+		if cacheVersion == "" {
+			cacheVersion = loadVersion()
+		}
+		v = cacheVersion
+		mu.Unlock()
 	}
+
 	resp := VersionResponse{
-		Version: cacheVersion,
+		Version: v,
 	}
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(resp); err != nil {
 		slog.Error("Error: not able to encode response", "error", err)
-		http.Error(w, "not able to process request", http.StatusInternalServerError)
+		WriteJSONError(w, "not able to process request", http.StatusInternalServerError)
 		return
 	}
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix data race and secure error responses

🚨 Severity: MEDIUM
💡 Vulnerability: Data race in `/version` and insecure error handling (plaintext errors without security headers).
🎯 Impact: Potential race conditions in high-concurrency environments and MIME-sniffing risks due to missing headers.
🔧 Fix: Added `sync.RWMutex` for version caching and a `WriteJSONError` helper for consistent, secure JSON errors.
✅ Verification: Ran `make test` and `make lint`. Added new unit tests for error paths and encoding failures.

The changes ensure thread safety and follow defense-in-depth principles by standardizing security headers across all API responses.

---
*PR created automatically by Jules for task [3299326732882982358](https://jules.google.com/task/3299326732882982358) started by @nikfarjam*